### PR TITLE
Fix slow search

### DIFF
--- a/pymispwarninglists/api.py
+++ b/pymispwarninglists/api.py
@@ -51,9 +51,9 @@ class WarningList():
 
         if self.slow_search and self.type == 'cidr':
             self._network_objects = self._network_index()
-        # If network objects is empty, reverting to default anyway
-        if not self._network_objects:
-            self.slow_search = False
+            # If network objects is empty, reverting to default anyway
+            if not self._network_objects:
+                self.slow_search = False
 
     def __repr__(self):
         return '<{self.__class__.__name__}(type="{self.name}", version="{self.version}", description="{self.description}")'.format(self=self)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -44,3 +44,5 @@ class TestPyMISPWarningLists(unittest.TestCase):
         self.assertEqual(results[0].name, 'List of RFC 3849 CIDR blocks')
         results = self.warninglists.search('1e100.net')
         self.assertEqual(results[0].name, 'List of known google domains')
+        results = self.warninglists.search('something.files.1drv.com')
+        self.assertEqual(results[0].name, 'List of known microsoft domains')


### PR DESCRIPTION
Hey,

I've noticed that the slow search is turned off if the warning list type is not `cidr`. Probably just an indentation typo.