### PR TITLE
chg: Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
     tests_requires=['nose'],
     test_suite='nose.collector',
     package_data={'pymispwarninglists': ['data/misp-warninglists/schema.json',
-                                         'data/misp-warninglists/*/*.json']}
+                                         'data/misp-warninglists/lists/*/*.json']}
 )


### PR DESCRIPTION
Hey,

when doing a `pip install` for the local package, the data from the misp-warninglists repo doesn't get copied to the installation directory. Fixed the pattern to copy the lists.