### PR TITLE
Fix UnicodeDecodeError on Windows.

### DIFF
--- a/pymispwarninglists/api.py
+++ b/pymispwarninglists/api.py
@@ -122,7 +122,7 @@ class WarningLists(collections.Mapping):
             lists = []
             self.root_dir_warninglists = Path(sys.modules['pymispwarninglists'].__file__).parent / 'data' / 'misp-warninglists' / 'lists'
             for warninglist_file in glob(str(self.root_dir_warninglists / '*' / 'list.json')):
-                with open(warninglist_file, 'r') as f:
+                with open(warninglist_file, mode='r', encoding="utf-8") as f:
                     lists.append(json.load(f))
         if not lists:
             raise PyMISPWarningListsError('Unable to load the lists. Do not forget to initialize the submodule (git submodule update --init).')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,7 +16,7 @@ class TestPyMISPWarningLists(unittest.TestCase):
     def test_dump_warninglists(self):
         warninglists_from_files = {}
         for warninglist_file in glob(os.path.join(self.warninglists.root_dir_warninglists, '*', 'list.json')):
-            with open(warninglist_file, 'r') as f:
+            with open(warninglist_file, mode='r', encoding="utf-8") as f:
                 warninglist = json.load(f)
             warninglists_from_files[warninglist['name']] = warninglist
         for name, w in self.warninglists.items():


### PR DESCRIPTION
Changed to explicitly specify the encoding(utf-8) when opening a JSON file because a UnicodeDecodeError occurs when loading JSON on Windows.